### PR TITLE
Feat/ 일기 상세 페이지 구현

### DIFF
--- a/src/components/DiaryListItem.jsx
+++ b/src/components/DiaryListItem.jsx
@@ -11,14 +11,17 @@ const DiaryListItem = ({ data }) => {
 
   return (
     <div className="DiaryListItem">
-      <div className={`img_section img_section_${emotionId}`}>
+      <div
+        onClick={() => nav(`/diary/${id}`)}
+        className={`img_section img_section_${emotionId}`}
+      >
         <img
           src={getEmotionImage(emotionId)}
           alt={`${emotionId}번 감정 이미지`}
         />
       </div>
 
-      <div className="info_section">
+      <div onClick={() => nav(`/diary/${id}`)} className="info_section">
         <div className="created_date">
           {new Date(createdDate).toLocaleDateString()}
         </div>
@@ -26,12 +29,7 @@ const DiaryListItem = ({ data }) => {
       </div>
 
       <div className="button_section">
-        <Button
-          onClick={() => {
-            nav(`/edit/${id}`);
-          }}
-          text={"수정하기"}
-        />
+        <Button onClick={() => nav(`/edit/${id}`)} text={"수정하기"} />
       </div>
     </div>
   );

--- a/src/components/DiaryListItem.jsx
+++ b/src/components/DiaryListItem.jsx
@@ -1,6 +1,7 @@
+import "./DiaryListItem.css";
+
 import { useNavigate } from "react-router-dom";
 import getEmotionImage from "../utils/getEmotionImage";
-import "./DiaryListItem.css";
 
 import Button from "./Button";
 

--- a/src/components/Editor.jsx
+++ b/src/components/Editor.jsx
@@ -1,6 +1,7 @@
+import "./Editor.css";
+
 import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
-import "./Editor.css";
 import getStringDate from "../utils/getStringDate";
 import emotionList from "../contents/emotionList";
 

--- a/src/components/Editor.jsx
+++ b/src/components/Editor.jsx
@@ -1,18 +1,11 @@
 import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
-import getStringDate from "../utils/getStringDate";
 import "./Editor.css";
+import getStringDate from "../utils/getStringDate";
+import emotionList from "../contents/emotionList";
 
 import Button from "./Button";
 import EmotionItem from "./EmotionItem";
-
-const emotionList = [
-  { emotionId: 1, emotionName: "완전 좋음" },
-  { emotionId: 2, emotionName: "좋음" },
-  { emotionId: 3, emotionName: "그럭저럭" },
-  { emotionId: 4, emotionName: "나쁨" },
-  { emotionId: 5, emotionName: "끔찍함" },
-];
 
 const Editor = ({ initData, onSubmit }) => {
   const nav = useNavigate();

--- a/src/components/EmotionItem.jsx
+++ b/src/components/EmotionItem.jsx
@@ -1,5 +1,6 @@
-import getEmotionImage from "../utils/getEmotionImage";
 import "./EmotionItem.css";
+
+import getEmotionImage from "../utils/getEmotionImage";
 
 const EmotionItem = ({ emotionId, emotionName, isSelected, onClick }) => {
   return (

--- a/src/components/Viewer.css
+++ b/src/components/Viewer.css
@@ -1,0 +1,57 @@
+.Viewer > section {
+  width: 100%;
+  margin-bottom: 50px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+}
+
+.Viewer > section > h4 {
+  font-size: 22px;
+  font-weight: bold;
+}
+
+.Viewer .emotion_img_wrapper {
+  width: 250px;
+  height: 250px;
+  border-radius: 5px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: space-around;
+  color: white;
+  font-size: 25px;
+}
+
+.Viewer .emotion_img_wrapper_1 {
+  background-color: rgb(100, 201, 100);
+}
+.Viewer .emotion_img_wrapper_2 {
+  background-color: rgb(157, 215, 114);
+}
+.Viewer .emotion_img_wrapper_3 {
+  background-color: rgb(253, 206, 23);
+}
+.Viewer .emotion_img_wrapper_4 {
+  background-color: rgb(253, 132, 70);
+}
+.Viewer .emotion_img_wrapper_5 {
+  background-color: rgb(253, 86, 95);
+}
+
+.Viewer .content_wrapper {
+  width: 100%;
+  background-color: rgb(236, 236, 236);
+  border-radius: 5px;
+  word-break: keep-all;
+  overflow-wrap: break-word;
+}
+
+.Viewer .content_wrapper > p {
+  padding: 20px;
+  text-align: left;
+  font-size: 20px;
+  font-weight: 400;
+  line-height: 2.5;
+}

--- a/src/components/Viewer.jsx
+++ b/src/components/Viewer.jsx
@@ -1,0 +1,33 @@
+import "./Viewer.css";
+import getEmotionImage from "../utils/getEmotionImage";
+import emotionList from "../contents/emotionList";
+
+const Viewer = ({ emotionId, content }) => {
+  const emotionItem = emotionList.find(
+    (item) => String(item.emotionId) === String(emotionId)
+  );
+
+  return (
+    <div className="Viewer">
+      <section className="img_section">
+        <h4>오늘의 감정</h4>
+        <div className={`emotion_img_wrapper emotion_img_wrapper_${emotionId}`}>
+          <img
+            src={getEmotionImage(emotionId)}
+            alt={`${emotionId}번 감정 이미지`}
+          />
+          <div>{emotionItem.emotionName}</div>
+        </div>
+      </section>
+
+      <section className="content_section">
+        <h4>오늘의 일기</h4>
+        <div className="content_wrapper">
+          <p>{content}</p>
+        </div>
+      </section>
+    </div>
+  );
+};
+
+export default Viewer;

--- a/src/components/Viewer.jsx
+++ b/src/components/Viewer.jsx
@@ -1,4 +1,5 @@
 import "./Viewer.css";
+
 import getEmotionImage from "../utils/getEmotionImage";
 import emotionList from "../contents/emotionList";
 

--- a/src/contents/emotionList.js
+++ b/src/contents/emotionList.js
@@ -1,0 +1,9 @@
+const emotionList = [
+  { emotionId: 1, emotionName: "완전 좋음" },
+  { emotionId: 2, emotionName: "좋음" },
+  { emotionId: 3, emotionName: "그럭저럭" },
+  { emotionId: 4, emotionName: "나쁨" },
+  { emotionId: 5, emotionName: "끔찍함" },
+];
+
+export default emotionList;

--- a/src/hooks/useDiaryData.jsx
+++ b/src/hooks/useDiaryData.jsx
@@ -1,0 +1,31 @@
+/**
+ *
+ * @param {*} id
+ * 원하는 일기의 정보를 반환
+ *
+ */
+import { useContext, useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { DiaryStateContext } from "../App";
+
+const useDiaryData = (id) => {
+  const nav = useNavigate();
+  const diaryData = useContext(DiaryStateContext);
+
+  const [currentDiaryData, setCurrentDiaryData] = useState();
+
+  useEffect(() => {
+    const data = diaryData.find((item) => String(item.id) === String(id));
+
+    if (!data) {
+      window.alert("존재하지 않는 일기입니다.");
+      nav("/", { replace: true });
+    }
+
+    setCurrentDiaryData(data);
+  }, [id]);
+
+  return currentDiaryData;
+};
+
+export default useDiaryData;

--- a/src/pages/Diary.jsx
+++ b/src/pages/Diary.jsx
@@ -1,11 +1,33 @@
-import { useParams } from "react-router-dom";
+import { useNavigate, useParams } from "react-router-dom";
+import useDiaryData from "../hooks/useDiaryData";
+import getStringDate from "../utils/getStringDate";
+
+import Header from "../components/Header";
+import Button from "../components/Button";
+import Viewer from "../components/Viewer";
 
 const Diary = () => {
   const params = useParams();
+  const nav = useNavigate();
+
+  const currentDiaryData = useDiaryData(params.id);
+  if (!currentDiaryData) {
+    return <div>Loading data...</div>;
+  }
+
+  const { createdDate, emotionId, content } = currentDiaryData;
+  const titleDate = getStringDate(new Date(createdDate));
 
   return (
     <div>
-      <h1>Welcome to the {params.id}th Diary Page</h1>
+      <Header
+        title={`${titleDate} 기록`}
+        leftChild={<Button onClick={() => nav(-1)} text={"< 뒤로 가기"} />}
+        rightChild={
+          <Button onClick={() => nav(`/edit/${params.id}`)} text={"수정하기"} />
+        }
+      />
+      <Viewer emotionId={emotionId} content={content} />
     </div>
   );
 };

--- a/src/pages/Edit.jsx
+++ b/src/pages/Edit.jsx
@@ -1,30 +1,18 @@
+import { useContext } from "react";
 import { useNavigate, useParams } from "react-router-dom";
+import { DiaryDispatchContext } from "../App";
+import useDiaryData from "../hooks/useDiaryData";
+
 import Header from "../components/Header";
 import Button from "../components/Button";
 import Editor from "../components/Editor";
-import { useContext, useEffect, useState } from "react";
-import { DiaryDispatchContext, DiaryStateContext } from "../App";
 
 const Edit = () => {
   const params = useParams();
   const nav = useNavigate();
-  const diaryData = useContext(DiaryStateContext);
   const { onDelete, onUpdate } = useContext(DiaryDispatchContext);
 
-  const [initData, setInitData] = useState();
-
-  useEffect(() => {
-    const currentDiaryData = diaryData.find(
-      (item) => String(item.id) === String(params.id)
-    );
-
-    if (!currentDiaryData) {
-      window.alert("존재하지 않는 일기입니다.");
-      nav("/", { replace: true });
-    }
-
-    setInitData(currentDiaryData);
-  }, [params.id]);
+  const currentDiaryData = useDiaryData(params.id);
 
   const onClickDelete = () => {
     if (window.confirm("일기를 정말 삭제할까요? 다시 복구되지 않아요")) {
@@ -54,7 +42,7 @@ const Edit = () => {
           <Button onClick={onClickDelete} text={"삭제하기"} type={"negative"} />
         }
       />
-      <Editor initData={initData} onSubmit={onClickSubmit} />
+      <Editor initData={currentDiaryData} onSubmit={onClickSubmit} />
     </div>
   );
 };

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -27,7 +27,6 @@ const Home = () => {
         leftChild={<Button text={"<"} onClick={handleDecreaseMonth} />}
         rightChild={<Button text={">"} onClick={handleIncreaseMonth} />}
       />
-
       <DiaryList diaryData={monthlyDiaryData} />
     </div>
   );


### PR DESCRIPTION
## ✏️ 변경 사항

- 일기 상세 페이지 구현
- 감정 리스트(emotionId, emotionName)를 상수로 분리
- `useDiaryData` 훅 생성 : 일기 아이디를 받아 해당 일기의 데이터를 반환

## 📸스크린샷 (UI 변경 사항이 있는 경우)

- 변경된 UI의 스크린샷
<img width="60%" height="60%" alt="image" src="https://github.com/user-attachments/assets/3b132835-ede8-47d9-a81a-3becf8067aad" />

## 🏷️ 기타

- 이 PR을 병합하는데 주의해야 할 사항
